### PR TITLE
correção dos nomes de instrumentos e retirando horário setado

### DIFF
--- a/src/service/database/index.ts
+++ b/src/service/database/index.ts
@@ -179,11 +179,11 @@ class Database {
           quantidade: 0,
         },
         {
-          instrumento: "Trompetete",
+          instrumento: "Trompete",
           quantidade: 0,
         },
         {
-          instrumento: "Cornete",
+          instrumento: "Cornet",
           quantidade: 0,
         },
         {

--- a/src/service/pdf/index.ts
+++ b/src/service/pdf/index.ts
@@ -69,7 +69,7 @@ class Pdf {
                           )}</td>
                       </tr>
                       <tr>
-                          <td>Horário: 09h</td>
+                          <td></td>
                       </tr>
                   </table>
               </div>


### PR DESCRIPTION
Correção da escrita dos nomes dos instrumentos: 
Trompetete para Trompete e Cornete para Cornet


Retirando horário do relatório gerado.